### PR TITLE
fix: force success if cloud9 fail to install

### DIFF
--- a/static/cfn.yml
+++ b/static/cfn.yml
@@ -518,7 +518,7 @@ Resources:
                 echo "alias kctx=ktx" | tee -a /home/ec2-user/.bashrc
 
                 echo '=== Installing c9 ==='
-                su -l -c 'npm i -g c9' || trueq
+                su -l -c 'npm i -g c9' || true
 
                 echo '=== Exporting ENV Vars ==='
                 su -l -c 'echo "export AWS_ACCOUNT_ID=${AWS::AccountId}" >> ~/.bashrc' ec2-user


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
if `npm i` fail, the line will fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
